### PR TITLE
Change pkgpath to reflect new .dmg layout

### DIFF
--- a/DeployStudio/DeployStudioAdmin.install.recipe
+++ b/DeployStudio/DeployStudioAdmin.install.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%/DeployStudioServer_v%version%.mpkg/Contents/Packages/deploystudioAdmin.pkg</string>
+				<string>%pathname%/DeployStudioServer_v%version%.pkg</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
The DeployStudio installer is now provided via distribution .pkg, at the root of the source .dmg.

```
> hdiutil attach /path/to/AutoPkg/Cache/com.github.triti.install.DeployStudioAdmin/downloads/DeployStudioServer_v1.7.8.dmg
> pkgutil --expand /Volumes/DeployStudioServer_v1.7.8/DeployStudioServer_v1.7.8.pkg /tmp/deploystudio-expanded
> ls /tmp/deploystudio-expanded
DeployStudioAdmin.pkg/             DeployStudioServerReplicaSync.pkg/ Resources/
DeployStudioServerPrefPane.pkg/    Distribution
```

Running `lsbom` on DeployStudioAdmin.pkg/Bom shows that this .pkg installs Admin, Runtime and Assistant as standard. Presumably the installing user would want the ReplicaSync and PrefPane .pkgs as well, so it's unnecessary to expand, reflatten and install the DeployStudioAdmin.pkg.