### PR TITLE
Basic python3 compatibility

### DIFF
--- a/ESET/EraAgentPostflightPlistCreator.py
+++ b/ESET/EraAgentPostflightPlistCreator.py
@@ -87,7 +87,7 @@ class EraAgentPostflightPlistCreator(Processor):
             return {}
         try:
             return FoundationPlist.readPlist(pathname)
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError(
                 'Could not read %s: %s' % (pathname, err))
 
@@ -96,7 +96,7 @@ class EraAgentPostflightPlistCreator(Processor):
         # pylint: disable=no-self-use
         try:
             FoundationPlist.writePlist(data, pathname)
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError(
                 'Could not write %s: %s' % (pathname, err))
 

--- a/ESET/EraAgentPostflightPlistCreator.py
+++ b/ESET/EraAgentPostflightPlistCreator.py
@@ -87,7 +87,7 @@ class EraAgentPostflightPlistCreator(Processor):
             return {}
         try:
             return FoundationPlist.readPlist(pathname)
-        except Exception as err:
+        except BaseException as err:
             raise ProcessorError(
                 'Could not read %s: %s' % (pathname, err))
 
@@ -96,7 +96,7 @@ class EraAgentPostflightPlistCreator(Processor):
         # pylint: disable=no-self-use
         try:
             FoundationPlist.writePlist(data, pathname)
-        except Exception as err:
+        except BaseException as err:
             raise ProcessorError(
                 'Could not write %s: %s' % (pathname, err))
 

--- a/ESET/EraAgentPostflightPlistCreator.py
+++ b/ESET/EraAgentPostflightPlistCreator.py
@@ -16,9 +16,9 @@
 """See docstring for EraAgentPostflightPlistCreator class."""
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
-import FoundationPlist
 
+import FoundationPlist
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["EraAgentPostflightPlistCreator"]
 

--- a/ESET/EraAgentPostflightPlistCreator.py
+++ b/ESET/EraAgentPostflightPlistCreator.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for EraAgentPostflightPlistCreator class."""
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import FoundationPlist
 

--- a/SharedProcessors/XMLReader.py
+++ b/SharedProcessors/XMLReader.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 
 from __future__ import absolute_import
+
 import os.path
 import xml.etree.cElementTree as ET
-import FoundationPlist
 
 from autopkglib import Processor, ProcessorError
 

--- a/SharedProcessors/XMLReader.py
+++ b/SharedProcessors/XMLReader.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import
 import os.path
 import xml.etree.cElementTree as ET
 import FoundationPlist


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.