### PR TITLE
Update Python path to reflect changes in macOS 12.3+

### DIFF
--- a/ESET/EraAgentPostflightPlistCreator.py
+++ b/ESET/EraAgentPostflightPlistCreator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2015 Tyler Riti
 #
@@ -25,58 +25,53 @@ __all__ = ["EraAgentPostflightPlistCreator"]
 
 class EraAgentPostflightPlistCreator(Processor):
     """Create postflight plist for the ESET Remote Administrator Agent package."""
+
     description = __doc__
     input_variables = {
         "input_plist_path": {
             "required": False,
-            "description":
-                ("File path to a plist; empty or undefined to start with "
-                 "an empty plist."),
+            "description": (
+                "File path to a plist; empty or undefined to start with "
+                "an empty plist."
+            ),
         },
         "output_plist_path": {
             "required": True,
-            "description":
-                "File path to a plist. Can be the same path as input_plist.",
+            "description": "File path to a plist. Can be the same path as input_plist.",
         },
         "eraa_server_hostname": {
             "required": True,
-            "description":
-                "Hostname of the ESET Remote Administrator server.",
+            "description": "Hostname of the ESET Remote Administrator server.",
         },
         "eraa_server_port": {
             "required": True,
-            "description":
-                "The ESET Remote Administrator server port.",
+            "description": "The ESET Remote Administrator server port.",
         },
         "eraa_peer_cert_pwd": {
             "required": False,
-            "description":
-                ("Client certificate password; empty or undefined if cert is "
-                 "unencrypted."),
+            "description": (
+                "Client certificate password; empty or undefined if cert is "
+                "unencrypted."
+            ),
         },
         "eraa_peer_cert_b64": {
             "required": True,
-            "description":
-                "Base64 encoded client certificate.",
+            "description": "Base64 encoded client certificate.",
         },
         "eraa_ca_cert_b64": {
             "required": False,
-            "description":
-                "Base64 encoded CA certificate.",
+            "description": "Base64 encoded CA certificate.",
         },
         "eraa_product_uuid": {
             "required": False,
-            "description":
-                "Product UUID.",
+            "description": "Product UUID.",
         },
         "eraa_initial_sg_token": {
             "required": False,
-            "description":
-                "Initial static group token.",
+            "description": "Initial static group token.",
         },
     }
-    output_variables = {
-    }
+    output_variables = {}
 
     __doc__ = description
 
@@ -88,8 +83,7 @@ class EraAgentPostflightPlistCreator(Processor):
         try:
             return FoundationPlist.readPlist(pathname)
         except Exception as err:
-            raise ProcessorError(
-                'Could not read %s: %s' % (pathname, err))
+            raise ProcessorError("Could not read %s: %s" % (pathname, err))
 
     def write_plist(self, data, pathname):
         """Write a plist to pathname."""
@@ -97,8 +91,7 @@ class EraAgentPostflightPlistCreator(Processor):
         try:
             FoundationPlist.writePlist(data, pathname)
         except Exception as err:
-            raise ProcessorError(
-                'Could not write %s: %s' % (pathname, err))
+            raise ProcessorError("Could not write %s: %s" % (pathname, err))
 
     def main(self):
         # read original plist (or empty plist)
@@ -128,6 +121,6 @@ class EraAgentPostflightPlistCreator(Processor):
         self.output("Updated plist at %s" % self.env["output_plist_path"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = EraAgentPostflightPlistCreator()
     PROCESSOR.execute_shell()

--- a/SharedProcessors/XMLReader.py
+++ b/SharedProcessors/XMLReader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 
 from __future__ import absolute_import
 
@@ -7,7 +7,7 @@ import xml.etree.cElementTree as ET
 
 from autopkglib import Processor, ProcessorError
 
-__all__ = ['XMLReader']
+__all__ = ["XMLReader"]
 
 
 class XMLReader(Processor):
@@ -28,13 +28,13 @@ class XMLReader(Processor):
     }
 
     def main(self):
-        elements = self.env['elements']
+        elements = self.env["elements"]
 
-        path = os.path.normpath(self.env['xml_path'])
+        path = os.path.normpath(self.env["xml_path"])
         if not os.path.exists(path):
             raise ProcessorError("Path '%s' does not exist!" % path)
 
-        self.output('Reading: %s' % path)
+        self.output("Reading: %s" % path)
         tree = ET.parse(path)
 
         root = tree.getroot()
@@ -42,38 +42,43 @@ class XMLReader(Processor):
         self.env["xml_reader_output_variables"] = {}
 
         for query in elements:
-            if not 'xpath' in query:
+            if not "xpath" in query:
                 raise ProcessorError("Query key 'xpath' is missing!")
 
-            xpath = query['xpath']
+            xpath = query["xpath"]
             try:
                 element = root.findall(xpath)[0]
             except IndexError:
-                raise ProcessorError("XPath '%s' could not be found in XML file %s!"
-                                     % (xpath, path))
+                raise ProcessorError(
+                    "XPath '%s' could not be found in XML file %s!" % (xpath, path)
+                )
 
-            if 'attributes' in query:
-                attributes = query['attributes']
+            if "attributes" in query:
+                attributes = query["attributes"]
                 for key, val in attributes.items():
                     self.env[val] = element.get(key)
                     if self.env[val] is None:
                         raise ProcessorError(
                             "Could not find attribute named '%s' at XPath '%s'!"
-                            % (key, xpath))
-                    self.output("Assigning value of '%s' to output variable '%s'"
-                                % (self.env[val], val))
-                    self.env["xml_reader_output_variables"][val] = (self.env[val])
+                            % (key, xpath)
+                        )
+                    self.output(
+                        "Assigning value of '%s' to output variable '%s'"
+                        % (self.env[val], val)
+                    )
+                    self.env["xml_reader_output_variables"][val] = self.env[val]
 
-            if 'text' in query:
-                var = query['text']
+            if "text" in query:
+                var = query["text"]
                 self.env[var] = element.text
                 if self.env[var] is None:
-                    raise ProcessorError("No text found at XPath '%s'!"
-                                         % xpath)
-                self.output("Assigning value of '%s' to output variable '%s'"
-                            % (self.env[var], var))
+                    raise ProcessorError("No text found at XPath '%s'!" % xpath)
+                self.output(
+                    "Assigning value of '%s' to output variable '%s'"
+                    % (self.env[var], var)
+                )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = XMLReader()
     PROCESSOR.execute_shell()


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. Similarly, Munki ships with its own Python 3 framework, symlinked from `/usr/local/munki/munki-python`. This pull request adjusts the shebang and interpreter paths of processors, pre/post install scripts, and other files to replace `/usr/bin/python` with the AutoPkg or Munki Python 3 symlinks as appropriate.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.