### PR TITLE
Dynamically get RCDefaultApp download URL

### DIFF
--- a/RCDefaultApp/RCDefaultApp.download.recipe
+++ b/RCDefaultApp/RCDefaultApp.download.recipe
@@ -10,20 +10,31 @@
 	<dict>
 		<key>NAME</key>
 		<string>RCDefaultApp</string>
-		<key>DOWNLOAD_URL</key>
-		<string>http://www.rubicode.com/Downloads/RCDefaultApp-2.1.X.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>(Downloads/RCDefaultApp\-[\d\.X]+\.dmg)</string>
+				<key>result_output_var_name</key>
+				<string>urlpath</string>
+				<key>url</key>
+				<string>https://www.rubicode.com/Software/RCDefaultApp/</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>https://www.rubicode.com/%urlpath%</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
This PR adjusts the RCDefaultApp download method to obtain a download URL dynamically instead of using a hard-coded URL.

The software hasn't been updated since 2009, so it's highly unlikely this will matter. But for as long as the website is active, we should ensure new versions are detected automatically.

Verbose recipe run output:

```
% autopkg run -vvq 'RCDefaultApp/RCDefaultApp.download.recipe'
Processing RCDefaultApp/RCDefaultApp.download.recipe...
WARNING: RCDefaultApp/RCDefaultApp.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(Downloads/RCDefaultApp\\-[\\d\\.X]+\\.dmg)',
           'result_output_var_name': 'urlpath',
           'url': 'https://www.rubicode.com/Software/RCDefaultApp/'}}
URLTextSearcher: Found matching text (urlpath): Downloads/RCDefaultApp-2.1.X.dmg
{'Output': {'urlpath': 'Downloads/RCDefaultApp-2.1.X.dmg'}}
URLDownloader
{'Input': {'url': 'https://www.rubicode.com/Downloads/RCDefaultApp-2.1.X.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 20 Sep 2009 03:38:29 GMT
URLDownloader: Storing new ETag header: "4ab5a3b5-6bce0"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.triti.download.RCDefaultApp/downloads/RCDefaultApp-2.1.X.dmg
{'Output': {'download_changed': True,
            'etag': '"4ab5a3b5-6bce0"',
            'last_modified': 'Sun, 20 Sep 2009 03:38:29 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.triti.download.RCDefaultApp/downloads/RCDefaultApp-2.1.X.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.triti.download.RCDefaultApp/downloads/RCDefaultApp-2.1.X.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.triti.download.RCDefaultApp/receipts/RCDefaultApp.download-receipt-20241228-120711.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.triti.download.RCDefaultApp/downloads/RCDefaultApp-2.1.X.dmg
```
